### PR TITLE
[FIX] updated syntax for redis cli

### DIFF
--- a/lib/ariadne/ariadne_util.rb
+++ b/lib/ariadne/ariadne_util.rb
@@ -29,6 +29,7 @@ module Ariadne
   def self.insert_data(options: {}, app_name: nil)
     raise 'Please specify data to be inserted for Ariadne.insert_data method!' if options.empty?
     raise 'Please specify id to be passed for Ariadne.insert_data method!' if options['id'].nil? || options['id'].size == 0
+
     DataUtil.insert_data_in_redis(options: options, app_name: get_app_name(app_name: app_name))
   rescue StandardError => e
     puts e

--- a/lib/ariadne/data_util.rb
+++ b/lib/ariadne/data_util.rb
@@ -3,6 +3,7 @@ module DataUtil
   # initialize the `redis` database connection object
   def self.init_redis_cli(redis_obj: nil)
     raise "Redis object not found!" if redis_obj.nil?
+
     @redis_cli = redis_obj
   rescue StandardError => e
     puts e
@@ -15,9 +16,9 @@ module DataUtil
     key  = id.nil? ? "#{app_name}*" : "#{app_name}:#{id}"
     keys = @redis_cli.keys key
     raise "Data not available for #{app_name}!" if keys.empty?
+
     keys.compact!
-    redis_data = (@redis_cli.mget keys)
-    redis_data
+    @redis_cli.mget keys
   rescue StandardError => e
     puts e
   end
@@ -27,9 +28,9 @@ module DataUtil
     key = "#{app_name}:#{options['id']}"
     options[:time] = Time.now
     redis_data = nil
-    @redis_cli.pipelined do
-      redis_data = @redis_cli.set key, options.to_json
-      @redis_cli.expire(key, (24 * 60 * 60)) # expire a key after 1 day
+    @redis_cli.pipelined do |pipeline|
+      redis_data = pipeline.set key, options.to_json
+      pipeline.expire(key, (24 * 60 * 60)) # expire a key after 1 day
     end
     redis_data
   end

--- a/lib/ariadne/version.rb
+++ b/lib/ariadne/version.rb
@@ -1,3 +1,3 @@
 module Ariadne
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
Fixes following error.

Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.